### PR TITLE
fix some test mockings in orderbook pr

### DIFF
--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -515,14 +515,17 @@ def test_get_ticker(default_conf, mocker):
     exchange.get_ticker(pair='ETH/BTC', refresh=True)
 
 
-def test_get_order_book(default_conf, mocker):
+def test_get_order_book(default_conf, mocker, order_book_l2):
     default_conf['exchange']['name'] = 'binance'
-    exchange = Exchange(default_conf)
-    order_book = exchange.get_order_book(pair='ETH/BTC', limit=50)
+    api_mock = MagicMock()
+
+    api_mock.fetch_l2_order_book = order_book_l2
+    exchange = get_patched_exchange(mocker, default_conf, api_mock)
+    order_book = exchange.get_order_book(pair='ETH/BTC', limit=10)
     assert 'bids' in order_book
     assert 'asks' in order_book
-    assert len(order_book['bids']) == 50
-    assert len(order_book['asks']) == 50
+    assert len(order_book['bids']) == 10
+    assert len(order_book['asks']) == 10
 
 
 def test_get_order_book_exception(default_conf, mocker):

--- a/freqtrade/tests/test_freqtradebot.py
+++ b/freqtrade/tests/test_freqtradebot.py
@@ -1946,12 +1946,17 @@ def test_order_book_depth_of_market_high_delta(default_conf, ticker, limit_buy_o
     assert trade is None
 
 
-def test_order_book_bid_strategy1(mocker, default_conf, order_book_l2) -> None:
+def test_order_book_bid_strategy1(mocker, default_conf, order_book_l2, markets) -> None:
     """
     test if function get_target_bid will return the order book price
     instead of the ask rate
     """
-    mocker.patch('freqtrade.exchange.Exchange.get_order_book', order_book_l2)
+    mocker.patch.multiple(
+        'freqtrade.exchange.Exchange',
+        validate_pairs=MagicMock(),
+        get_markets=markets,
+        get_order_book=order_book_l2
+    )
     default_conf['exchange']['name'] = 'binance'
     default_conf['experimental']['bid_strategy']['use_order_book'] = True
     default_conf['experimental']['bid_strategy']['order_book_top'] = 2
@@ -1962,12 +1967,17 @@ def test_order_book_bid_strategy1(mocker, default_conf, order_book_l2) -> None:
     assert freqtrade.get_target_bid('ETH/BTC', {'ask': 0.045, 'last': 0.046}) == 0.043935
 
 
-def test_order_book_bid_strategy2(mocker, default_conf, order_book_l2) -> None:
+def test_order_book_bid_strategy2(mocker, default_conf, order_book_l2, markets) -> None:
     """
     test if function get_target_bid will return the ask rate (since its value is lower)
     instead of the order book rate (even if enabled)
     """
-    mocker.patch('freqtrade.exchange.Exchange.get_order_book', order_book_l2)
+    mocker.patch.multiple(
+           'freqtrade.exchange.Exchange',
+           validate_pairs=MagicMock(),
+           get_markets=markets,
+           get_order_book=order_book_l2
+    )
     default_conf['exchange']['name'] = 'binance'
     default_conf['experimental']['bid_strategy']['use_order_book'] = True
     default_conf['experimental']['bid_strategy']['order_book_top'] = 2
@@ -1978,12 +1988,17 @@ def test_order_book_bid_strategy2(mocker, default_conf, order_book_l2) -> None:
     assert freqtrade.get_target_bid('ETH/BTC', {'ask': 0.042, 'last': 0.046}) == 0.042
 
 
-def test_order_book_bid_strategy3(default_conf, mocker, order_book_l2) -> None:
+def test_order_book_bid_strategy3(default_conf, mocker, order_book_l2, markets) -> None:
     """
     test if function get_target_bid will return ask rate instead
     of the order book rate
     """
-    mocker.patch('freqtrade.exchange.Exchange.get_order_book', order_book_l2)
+    mocker.patch.multiple(
+        'freqtrade.exchange.Exchange',
+        validate_pairs=MagicMock(),
+        get_markets=markets,
+        get_order_book=order_book_l2
+    )
     default_conf['exchange']['name'] = 'binance'
     default_conf['experimental']['bid_strategy']['use_order_book'] = True
     default_conf['experimental']['bid_strategy']['order_book_top'] = 1
@@ -1995,11 +2010,16 @@ def test_order_book_bid_strategy3(default_conf, mocker, order_book_l2) -> None:
     assert freqtrade.get_target_bid('ETH/BTC', {'ask': 0.03, 'last': 0.029}) == 0.03
 
 
-def test_check_depth_of_market_buy(default_conf, mocker, order_book_l2) -> None:
+def test_check_depth_of_market_buy(default_conf, mocker, order_book_l2, markets) -> None:
     """
     test check depth of market
     """
-    mocker.patch('freqtrade.exchange.Exchange.get_order_book', order_book_l2)
+    mocker.patch.multiple(
+        'freqtrade.exchange.Exchange',
+        validate_pairs=MagicMock(),
+        get_markets=markets,
+        get_order_book=order_book_l2
+    )
     default_conf['telegram']['enabled'] = False
     default_conf['exchange']['name'] = 'binance'
     default_conf['experimental']['check_depth_of_market']['enabled'] = True


### PR DESCRIPTION
Hi there, 

first of all, sorry it took so long to have a look at the orderbook-PR again.

While testing your PR i noticed a few no-mocked calls going to the exchange.
While not really problematic per se - it can (and probably will at some point) create random test-failures should there happen a problem with the exchange api.




